### PR TITLE
Ensure `compileKotlin` and `compileJava` compile to same JVM target (`11`)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,12 @@ plugins {
     id("org.jetbrains.compose")
 }
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
 repositories {
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")


### PR DESCRIPTION
Fixes the below warning during compilation

![Screenshot 2023-06-05 at 3 05 27 PM](https://github.com/JetBrains/compose-multiplatform-desktop-template/assets/3940492/9add7b7d-b2b1-4c96-b7c9-c3b39fc14c50)
